### PR TITLE
Fix case of Makefile template

### DIFF
--- a/lib/template.ex
+++ b/lib/template.ex
@@ -3,6 +3,5 @@ defmodule Nifty.Template do
 
   EEx.function_from_file :def, :elixir_nif, "priv/templates/nif.ex.eex", [:name, :mod]
   EEx.function_from_file :def, :nif, "priv/templates/nif.c.eex", [:name, :mod]
-  EEx.function_from_file :def, :makefile, "priv/templates/makefile.eex", [:name]
-
+  EEx.function_from_file :def, :makefile, "priv/templates/Makefile.eex", [:name]
 end


### PR DESCRIPTION
Some (operating/file) systems are case-sensitive (like Linux).
Therefore the filenames have to be addressed with correct case.
